### PR TITLE
PDL og stoppe arbeidsgivernotifikasjoner ved adressesperre

### DIFF
--- a/nais/nais-dev.yml
+++ b/nais/nais-dev.yml
@@ -52,7 +52,6 @@ spec:
       rules:
         - application: "notifikasjon-produsent-api"
           namespace: "fager"
-        - application: pdl-api
-          namespace: pdl
       external:
         - host: team-tiltak-unleash-api.nav.cloud.nais.io
+        - host: pdl-api.dev-fss-pub.nais.io

--- a/nais/nais-dev.yml
+++ b/nais/nais-dev.yml
@@ -52,5 +52,7 @@ spec:
       rules:
         - application: "notifikasjon-produsent-api"
           namespace: "fager"
+        - application: pdl-api
+          namespace: pdl
       external:
         - host: team-tiltak-unleash-api.nav.cloud.nais.io

--- a/nais/nais-prod.yml
+++ b/nais/nais-prod.yml
@@ -59,5 +59,7 @@ spec:
       rules:
         - application: "notifikasjon-produsent-api"
           namespace: "fager"
+        - application: pdl-api
+          namespace: pdl
       external:
         - host: team-tiltak-unleash-api.nav.cloud.nais.io

--- a/nais/nais-prod.yml
+++ b/nais/nais-prod.yml
@@ -59,7 +59,6 @@ spec:
       rules:
         - application: "notifikasjon-produsent-api"
           namespace: "fager"
-        - application: pdl-api
-          namespace: pdl
       external:
         - host: team-tiltak-unleash-api.nav.cloud.nais.io
+        - host: pdl-api.prod-fss-pub.nais.io

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>no.nav.team-tiltak</groupId>
+			<artifactId>tiltak-persondata</artifactId>
+			<version>2025.04.07_08.09-c5b0327d047a</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -8,11 +8,11 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.Arbeidsgivernot
 import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.ArbeidsgivernotifikasjonStatus
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleOpphav
-import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.Brukernotifikasjon
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonRepository
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonService
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonStatus
+import no.nav.tiltak.tiltaknotifikasjon.persondata.PersondataService
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
 import no.nav.tiltak.tiltaknotifikasjon.utils.ulid
 import org.slf4j.LoggerFactory
@@ -28,7 +28,8 @@ class AvtaleHendelseConsumer(
     val arbeidsgiverNotifikasjonService: ArbeidsgiverNotifikasjonService,
     val brukernotifikasjonRepository: BrukernotifikasjonRepository,
     val arbeidsgivernotifikasjonRepository: ArbeidsgivernotifikasjonRepository,
-    val unleash: Unleash
+    val unleash: Unleash,
+    val persondataService: PersondataService
 ) {
     private val mapper = jacksonMapper()
     private val log = LoggerFactory.getLogger(javaClass)
@@ -68,6 +69,7 @@ class AvtaleHendelseConsumer(
         try {
             val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
             if (!sjekkOmAvtaleFraArenaSkalBehandles(melding)) return
+            if (persondataService.hentDiskresjonskode(melding.deltakerFnr).erKode6Eller7()) return
             arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(melding)
         } catch (e: Exception) {
             val arbeidsgivernotifikasjon = Arbeidsgivernotifikasjon(

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -69,8 +69,7 @@ class AvtaleHendelseConsumer(
 
         try {
             val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
-            if (!sjekkOmAvtaleFraArenaSkalBehandles(melding)) return
-            if (erKode6Eller7OgSkalIkkeBehandles(melding)) return
+            if (!skalArbeidsgivernotifikasjonBehanldes(melding)) return
             arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(melding)
         } catch (e: Exception) {
             val arbeidsgivernotifikasjon = Arbeidsgivernotifikasjon(
@@ -85,16 +84,19 @@ class AvtaleHendelseConsumer(
         }
     }
 
-    private fun erKode6Eller7OgSkalIkkeBehandles(melding: AvtaleHendelseMelding): Boolean {
-        // Returnerer true på kode 6 og 7, unntatt de tilfellene hvor meldingstypen er STATUSENDRING eller ANNULLERT. Dette for å kunne lukke Saker.
-        val erKode6Eller7 = persondataService.hentDiskresjonskode(melding.deltakerFnr).erKode6Eller7()
-        if (!erKode6Eller7) return false
-        return !(melding.hendelseType == HendelseType.STATUSENDRING || melding.hendelseType == HendelseType.ANNULLERT)
-    }
-
     private fun sjekkOmAvtaleFraArenaSkalBehandles(avtaleHendelse: AvtaleHendelseMelding): Boolean {
         if (avtaleHendelse.opphav == AvtaleOpphav.ARENA && avtaleHendelse.avtaleInngått == null) return false
         return true
+    }
+
+    private fun skalArbeidsgivernotifikasjonBehanldes(avtaleHendelsemelding: AvtaleHendelseMelding): Boolean {
+        // Arena-sjekk - ikke behandle meldinger på migrerte avtaler fra arena før de er inngått.
+        if (avtaleHendelsemelding.opphav == AvtaleOpphav.ARENA && avtaleHendelsemelding.avtaleInngått == null) return false
+        // Diskresjonssjekk - Behandle kun kode 6/7 hvis det er statusendring eller annullert
+        val erKode6Eller7 = persondataService.hentDiskresjonskode(avtaleHendelsemelding.deltakerFnr).erKode6Eller7()
+        if (!erKode6Eller7) return true
+        if (avtaleHendelsemelding.hendelseType == HendelseType.STATUSENDRING || avtaleHendelsemelding.hendelseType == HendelseType.ANNULLERT) return true
+        return false
     }
 
     private fun sjekkToggle(toggle: String): Boolean {

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/persondata/PersondataProperties.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/persondata/PersondataProperties.kt
@@ -1,0 +1,10 @@
+package no.nav.tiltak.tiltaknotifikasjon.persondata
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationProperties(prefix = "tiltak-notifikasjon.pdl-api")
+data class PersondataProperties(
+    var uri: String = "",
+)

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/persondata/PersondataService.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/persondata/PersondataService.kt
@@ -1,0 +1,35 @@
+package no.nav.tiltak.tiltaknotifikasjon.persondata
+
+import no.nav.security.token.support.client.core.oauth2.OAuth2AccessTokenService
+import no.nav.security.token.support.client.spring.ClientConfigurationProperties
+import no.nav.team_tiltak.felles.persondata.PersondataClient
+import no.nav.team_tiltak.felles.persondata.pdl.domene.Diskresjonskode
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+
+@Service
+@Profile("prod-gcp", "dev-gcp", "dockercompose")
+class PersondataService(
+    clientConfigurationProperties: ClientConfigurationProperties,
+    persondataProperties: PersondataProperties,
+    val oAuth2AccessTokenService: OAuth2AccessTokenService,
+) {
+    private val clientProperties = clientConfigurationProperties.registration["pdl-api"]
+
+    private val persondataClient =
+        PersondataClient(persondataProperties.uri) { clientProperties?.let { oAuth2AccessTokenService.getAccessToken(it).access_token } }
+
+    fun hentDiskresjonskode(fnr: String): Diskresjonskode {
+        return persondataClient.hentDiskresjonskode(fnr).orElse(Diskresjonskode.UGRADERT)
+    }
+
+    // TRENGER VEL IKKE DENNE
+    fun hentDiskresjonskoder(fnrSet: Set<String>): Map<String, Diskresjonskode> {
+        return persondataClient.hentDiskresjonskoderEllerDefault(
+            fnrSet.map { it }.toSet(),
+            { fnr: String -> fnr },
+            Diskresjonskode.UGRADERT
+        )
+    }
+
+}

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/persondata/PersondataService.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/persondata/PersondataService.kt
@@ -23,13 +23,4 @@ class PersondataService(
         return persondataClient.hentDiskresjonskode(fnr).orElse(Diskresjonskode.UGRADERT)
     }
 
-    // TRENGER VEL IKKE DENNE
-    fun hentDiskresjonskoder(fnrSet: Set<String>): Map<String, Diskresjonskode> {
-        return persondataClient.hentDiskresjonskoderEllerDefault(
-            fnrSet.map { it }.toSet(),
-            { fnr: String -> fnr },
-            Diskresjonskode.UGRADERT
-        )
-    }
-
 }

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -15,7 +15,7 @@ tiltak-notifikasjon:
     vtaoServiceCode: 5516
     vtaoServiceEdition: 6
   pdl-api:
-    uri: https://pdl-api.dev.intern.nav.no/graphql
+    uri: https://pdl-api.dev-fss-pub.nais.io/graphql
     scope: api://dev-fss.pdl.pdl-api/.default
 
   produsent-api:

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -35,3 +35,7 @@ no.nav.security.jwt:
         token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
         grant-type: client_credentials
         scope: ${tiltak-notifikasjon.pdl-api.scope}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic

--- a/src/main/resources/application-dev-gcp.yml
+++ b/src/main/resources/application-dev-gcp.yml
@@ -14,6 +14,9 @@ tiltak-notifikasjon:
     inkluderingstilskuddServiceEdition: 5
     vtaoServiceCode: 5516
     vtaoServiceEdition: 6
+  pdl-api:
+    uri: https://pdl-api.dev.intern.nav.no/graphql
+    scope: api://dev-fss.pdl.pdl-api/.default
 
   produsent-api:
     url: http://notifikasjon-produsent-api.fager/api/graphql
@@ -28,3 +31,7 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl-api:
+        token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
+        grant-type: client_credentials
+        scope: ${tiltak-notifikasjon.pdl-api.scope}

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -14,6 +14,9 @@ tiltak-notifikasjon:
     inkluderingstilskuddServiceEdition: 5
     vtaoServiceCode: 5516
     vtaoServiceEdition: 6
+  pdl-api:
+    uri: https://pdl-api.dev.intern.nav.no/graphql
+    scope: api://prod-fss.pdl.pdl-api/.default
 
   produsent-api:
     url: http://notifikasjon-produsent-api.fager/api/graphql
@@ -28,3 +31,7 @@ no.nav.security.jwt:
           client-id: ${AZURE_APP_CLIENT_ID}
           client-secret: ${AZURE_APP_CLIENT_SECRET}
           client-auth-method: client_secret_basic
+      pdl-api:
+        token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
+        grant-type: client_credentials
+        scope: ${tiltak-notifikasjon.pdl-api.scope}

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -35,3 +35,7 @@ no.nav.security.jwt:
         token-endpoint-url: https://login.microsoftonline.com/${AZURE_APP_TENANT_ID}/oauth2/v2.0/token
         grant-type: client_credentials
         scope: ${tiltak-notifikasjon.pdl-api.scope}
+        authentication:
+          client-id: ${AZURE_APP_CLIENT_ID}
+          client-secret: ${AZURE_APP_CLIENT_SECRET}
+          client-auth-method: client_secret_basic

--- a/src/main/resources/application-prod-gcp.yml
+++ b/src/main/resources/application-prod-gcp.yml
@@ -15,7 +15,7 @@ tiltak-notifikasjon:
     vtaoServiceCode: 5516
     vtaoServiceEdition: 6
   pdl-api:
-    uri: https://pdl-api.dev.intern.nav.no/graphql
+    uri: https://pdl-api.prod-fss-pub.nais.io/graphql
     scope: api://prod-fss.pdl.pdl-api/.default
 
   produsent-api:

--- a/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonServiceTest.kt
@@ -8,7 +8,6 @@ import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleStatus
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
 import no.nav.tiltak.tiltaknotifikasjon.kafka.TiltakNotifikasjonKvitteringProdusent
-import no.nav.tiltak.tiltaknotifikasjon.persondata.PersondataService
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -344,7 +343,6 @@ class ArbeidsgiverNotifikasjonServiceTest {
         arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(statusEndringMelding) // Generer sakstatusEndret
         val sak = arbeidsgivernotifikasjonRepository.findSakByAvtaleId(opprettetMelding.avtaleId.toString())
         assertThat(sak?.hardDeleteSkedulertTidspunkt).isNotNull()
-
         arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(forlengetMelding) // Generer sakstatusEndret
         val sak2 = arbeidsgivernotifikasjonRepository.findSakByAvtaleId(opprettetMelding.avtaleId.toString())
         assertThat(sak2?.hardDeleteSkedulertTidspunkt).isNotNull()

--- a/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonServiceTest.kt
@@ -8,6 +8,7 @@ import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleStatus
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
 import no.nav.tiltak.tiltaknotifikasjon.kafka.TiltakNotifikasjonKvitteringProdusent
+import no.nav.tiltak.tiltaknotifikasjon.persondata.PersondataService
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -343,6 +344,7 @@ class ArbeidsgiverNotifikasjonServiceTest {
         arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(statusEndringMelding) // Generer sakstatusEndret
         val sak = arbeidsgivernotifikasjonRepository.findSakByAvtaleId(opprettetMelding.avtaleId.toString())
         assertThat(sak?.hardDeleteSkedulertTidspunkt).isNotNull()
+
         arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(forlengetMelding) // Generer sakstatusEndret
         val sak2 = arbeidsgivernotifikasjonRepository.findSakByAvtaleId(opprettetMelding.avtaleId.toString())
         assertThat(sak2?.hardDeleteSkedulertTidspunkt).isNotNull()

--- a/src/test/resources/application-test-containers.yml
+++ b/src/test/resources/application-test-containers.yml
@@ -26,3 +26,6 @@ tiltak-notifikasjon:
     mentorServiceEdition: 4
     inkluderingstilskuddServiceCode: 5516
     inkluderingstilskuddServiceEdition: 5
+
+  pdl-api:
+    uri: http://localhost:${wiremock.port}/persondata


### PR DESCRIPTION
Stopper utsending av notifikasjoner til arbeidsgiver helt, i de tilfellene hvor deltaker skulle ha adressesperre. 
Dette gjøres da vi har gått for en tilgangskontroll i tiltaksgjennomføring som krever tiltakstype tilgang + en ny adresseperre tilgang som arbeidsgiver. Dette støtter ikke team fager / min-side-arbeidsgiver, og vi har dermed besluttet at det greieste er å droppe utsending av notifikasjoner for disse.


Todoo: Kanskje skrive en test?...


Edit:
Må man ha extern host, og ikke outbound application?
ref: https://pdl-docs.ansatt.nav.no/ekstern/index.html#_miljoe