### PR TITLE
klar for visning istedenfor inngått

### DIFF
--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonService.kt
@@ -20,7 +20,7 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.graphql.generat
 import no.nav.tiltak.tiltaknotifikasjon.avtale.*
 import no.nav.tiltak.tiltaknotifikasjon.kafka.TiltakNotifikasjonKvitteringProdusent
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
-import no.nav.tiltak.tiltaknotifikasjon.utils.mentorAvtaleErKlarForVisningForEksterne
+import no.nav.tiltak.tiltaknotifikasjon.utils.erOpphavArenaOgErKlarforvisning
 import no.nav.tiltak.tiltaknotifikasjon.utils.ulid
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -62,7 +62,7 @@ class ArbeidsgiverNotifikasjonService(
                 }
 
                 HendelseType.ENDRET -> {
-                    if (avtaleHendelse.opphav == AvtaleOpphav.ARENA && mentorAvtaleErKlarForVisningForEksterne(avtaleHendelse, Avtalerolle.ARBEIDSGIVER)) {
+                    if (erOpphavArenaOgErKlarforvisning(avtaleHendelse, Avtalerolle.ARBEIDSGIVER)) {
                         // Vi skal gjøre det samme som ved opprettelse her, men kun 1 gang, og kun hvis den er klar for visning til eksterne
                         log.info("AG: Avtale endret fra Arena: sjekker om sak finnes, hvis ikke lager sak og oppgave. avtaleId: ${avtaleHendelse.avtaleId}")
                         val eksisterendeSak = arbeidsgivernotifikasjonRepository.findSakByAvtaleId(avtaleHendelse.avtaleId.toString())
@@ -158,7 +158,7 @@ class ArbeidsgiverNotifikasjonService(
                             softDeleteOppgaverOgBeskjeder(notifikasjoner, avtaleHendelse)
                         }
 
-                        if (avtaleHendelse.opphav != AvtaleOpphav.ARENA || mentorAvtaleErKlarForVisningForEksterne(avtaleHendelse, Avtalerolle.ARBEIDSGIVER)) {
+                        if (avtaleHendelse.opphav != AvtaleOpphav.ARENA || erOpphavArenaOgErKlarforvisning(avtaleHendelse, Avtalerolle.ARBEIDSGIVER)) {
                             // Vi sender ikke beskjed om annullering på opphav Arena avtaler. OBS: Kun de som ikke er inngått vil være utilgjengelige for arbeidsgiver.
                             // Send beskjed om annullering (ikke feilregistrert)
                             log.info("AG: Avtale annullert. lager beskjed om annullering. avtaleId: ${avtaleHendelse.avtaleId}")

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonService.kt
@@ -20,6 +20,7 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.graphql.generat
 import no.nav.tiltak.tiltaknotifikasjon.avtale.*
 import no.nav.tiltak.tiltaknotifikasjon.kafka.TiltakNotifikasjonKvitteringProdusent
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
+import no.nav.tiltak.tiltaknotifikasjon.utils.mentorAvtaleErKlarForVisningForEksterne
 import no.nav.tiltak.tiltaknotifikasjon.utils.ulid
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
@@ -58,6 +59,28 @@ class ArbeidsgiverNotifikasjonService(
                     val notifikasjonOppgave = nyArbeidsgivernotifikasjon(avtaleHendelse, ArbeidsgivernotifikasjonType.Oppgave, Varslingsformål.GODKJENNING_AV_AVTALE, nyOppgave)
                     arbeidsgivernotifikasjonRepository.save(notifikasjonOppgave)
                     opprettNyOppgave(nyOppgave, notifikasjonOppgave)
+                }
+
+                HendelseType.ENDRET -> {
+                    if (avtaleHendelse.opphav == AvtaleOpphav.ARENA && mentorAvtaleErKlarForVisningForEksterne(avtaleHendelse, Avtalerolle.ARBEIDSGIVER)) {
+                        // Vi skal gjøre det samme som ved opprettelse her, men kun 1 gang, og kun hvis den er klar for visning til eksterne
+                        log.info("AG: Avtale endret fra Arena: sjekker om sak finnes, hvis ikke lager sak og oppgave. avtaleId: ${avtaleHendelse.avtaleId}")
+                        val eksisterendeSak = arbeidsgivernotifikasjonRepository.findSakByAvtaleId(avtaleHendelse.avtaleId.toString())
+                        if (eksisterendeSak == null) {
+                            // Sak
+                            val nySak = nySak(avtaleHendelse, altinnProperties)
+                            val notifikasjon = nyArbeidsgivernotifikasjon(avtaleHendelse, ArbeidsgivernotifikasjonType.Sak, Varslingsformål.GODKJENNING_AV_AVTALE, nySak)
+                            arbeidsgivernotifikasjonRepository.save(notifikasjon)
+                            opprettNySak(nySak, notifikasjon)
+                            //Oppgave (på saken - via grupperingsId)
+                            val nyOppgave = nyOppgave(avtaleHendelse, altinnProperties)
+                            val notifikasjonOppgave = nyArbeidsgivernotifikasjon(avtaleHendelse, ArbeidsgivernotifikasjonType.Oppgave, Varslingsformål.GODKJENNING_AV_AVTALE, nyOppgave)
+                            arbeidsgivernotifikasjonRepository.save(notifikasjonOppgave)
+                            opprettNyOppgave(nyOppgave, notifikasjonOppgave)
+                        } else {
+                            log.info("AG: Avtale med opphav ARENA endret: sak finnes allerede, gjør ingenting. avtaleId: ${avtaleHendelse.avtaleId}")
+                        }
+                    }
                 }
 
                 HendelseType.GODKJENT_AV_ARBEIDSGIVER,
@@ -135,8 +158,9 @@ class ArbeidsgiverNotifikasjonService(
                             softDeleteOppgaverOgBeskjeder(notifikasjoner, avtaleHendelse)
                         }
 
-                        if (avtaleHendelse.opphav != AvtaleOpphav.ARENA) {
-                            // Send beskjed om annullering
+                        if (avtaleHendelse.opphav != AvtaleOpphav.ARENA || mentorAvtaleErKlarForVisningForEksterne(avtaleHendelse, Avtalerolle.ARBEIDSGIVER)) {
+                            // Vi sender ikke beskjed om annullering på opphav Arena avtaler. OBS: Kun de som ikke er inngått vil være utilgjengelige for arbeidsgiver.
+                            // Send beskjed om annullering (ikke feilregistrert)
                             log.info("AG: Avtale annullert. lager beskjed om annullering. avtaleId: ${avtaleHendelse.avtaleId}")
                             val nyBeskjed = nyBeskjed(avtaleHendelse, altinnProperties)
                             val notifikasjon = nyArbeidsgivernotifikasjon(avtaleHendelse, ArbeidsgivernotifikasjonType.Beskjed, Varslingsformål.AVTALE_ANNULLERT, nyBeskjed)
@@ -155,15 +179,6 @@ class ArbeidsgiverNotifikasjonService(
 
                 // BESKJEDER
                 HendelseType.AVTALE_INNGÅTT -> {
-                    if (avtaleHendelse.opphav == AvtaleOpphav.ARENA) {
-                        // Sak
-                        log.info("AG: Avtale med opphav Arena inngått: lager sak. avtaleId: ${avtaleHendelse.avtaleId}")
-                        val nySak = nySak(avtaleHendelse, altinnProperties)
-                        val notifikasjon = nyArbeidsgivernotifikasjon(avtaleHendelse, ArbeidsgivernotifikasjonType.Sak, Varslingsformål.AVTALE_INNGÅTT, nySak)
-                        arbeidsgivernotifikasjonRepository.save(notifikasjon)
-                        opprettNySak(nySak, notifikasjon)
-                    }
-
                     log.info("AG: Avtale inngått: lager beskjed. avtaleId: ${avtaleHendelse.avtaleId}")
                     val nyBeskjed = nyBeskjed(avtaleHendelse, altinnProperties)
                     val notifikasjon = nyArbeidsgivernotifikasjon(avtaleHendelse, ArbeidsgivernotifikasjonType.Beskjed, Varslingsformål.AVTALE_INNGÅTT, nyBeskjed)

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/AvtaleHendelseMelding.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/AvtaleHendelseMelding.kt
@@ -24,16 +24,41 @@ data class AvtaleHendelseMelding(
     val deltakerFnr: String,
     val deltakerFornavn: String?,
     val deltakerEtternavn: String?,
+    val deltakerTlf: String?,
+    val arbeidsgiverFornavn: String?,
+    val arbeidsgiverEtternavn: String?,
     val arbeidsgiverTlf: String?,
     val avtaleId: UUID,
     val avtaleNr: Int,
     val sistEndret: Instant,
     val veilederNavIdent: String?,
+    val veilederFornavn: String?,
+    val veilederEtternavn: String?,
+    val veilederTlf: String?,
+    val oppfolging: String?,
+    val tilrettelegging: String?,
     val annullertGrunn: String?,
     val antallDagerPerUke: BigDecimal?,
     val godkjentAvDeltaker: LocalDateTime?,
     val feilregistrert: Boolean,
-    val opphav: AvtaleOpphav?
+    val opphav: AvtaleOpphav?,
+    // Mentor-spesifikke felter
+    val mentorFornavn: String?,
+    val mentorEtternavn: String?,
+    val mentorOppgaver: String?,
+    val mentorAntallTimer: Double?,
+    val mentorTimelonn: Int?,
+    val mentorTlf: String?,
+    // Tilskuddsperiode-felter (mentor)
+    val arbeidsgiverKontonummer: String?,
+    val feriepengesats: BigDecimal?,
+    val otpSats: BigDecimal?,
+    val arbeidsgiveravgift: BigDecimal?,
+    val mentorValgtLonnstype: String?,
+    val mentorValgtLonnstypeBelop: Int?,
+    // Familietilknytning
+    val harFamilietilknytning: Boolean?,
+    val familietilknytningForklaring: String?,
 )
 
 enum class AvtaleOpphav {

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/AvtaleRolle.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/AvtaleRolle.kt
@@ -1,0 +1,13 @@
+package no.nav.tiltak.tiltaknotifikasjon.avtale
+
+enum class Avtalerolle {
+    DELTAKER, MENTOR, ARBEIDSGIVER, VEILEDER, BESLUTTER;
+
+    fun erInternBruker(): Boolean {
+        return this == Avtalerolle.VEILEDER || this == Avtalerolle.BESLUTTER
+    }
+
+    fun erBeslutter(): Boolean {
+        return this == Avtalerolle.BESLUTTER
+    }
+}

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -16,7 +16,7 @@ import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonS
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonStatus
 import no.nav.tiltak.tiltaknotifikasjon.persondata.PersondataService
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
-import no.nav.tiltak.tiltaknotifikasjon.utils.mentorAvtaleErKlarForVisningForEksterne
+import no.nav.tiltak.tiltaknotifikasjon.utils.erOpphavArenaOgErKlarforvisning
 import no.nav.tiltak.tiltaknotifikasjon.utils.ulid
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Profile
@@ -87,13 +87,13 @@ class AvtaleHendelseConsumer(
     }
 
     private fun sjekkOmAvtaleFraArenaSkalBehandles(avtaleHendelse: AvtaleHendelseMelding): Boolean {
-        if (avtaleHendelse.opphav == AvtaleOpphav.ARENA && !mentorAvtaleErKlarForVisningForEksterne(avtaleHendelse, Avtalerolle.DELTAKER)) return false
+        if (!erOpphavArenaOgErKlarforvisning(avtaleHendelse, Avtalerolle.DELTAKER)) return false
         return true
     }
 
     private fun skalArbeidsgivernotifikasjonBehanldes(avtaleHendelsemelding: AvtaleHendelseMelding): Boolean {
         // Arena-sjekk - ikke behandle meldinger på migrerte avtaler fra arena før de er tilgjengelige for arbeidsgiver.
-        if (avtaleHendelsemelding.opphav == AvtaleOpphav.ARENA && !mentorAvtaleErKlarForVisningForEksterne(avtaleHendelsemelding, Avtalerolle.ARBEIDSGIVER)) return false
+        if (!erOpphavArenaOgErKlarforvisning(avtaleHendelsemelding, Avtalerolle.ARBEIDSGIVER)) return false
         // Diskresjonssjekk - Behandle kun kode 6/7 hvis det er statusendring eller annullert
         val erKode6Eller7 = persondataService.hentDiskresjonskode(avtaleHendelsemelding.deltakerFnr).erKode6Eller7()
         if (!erKode6Eller7) return true

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
@@ -39,7 +39,8 @@ fun jacksonMapperSomIkkeBryrSegOmEnumCase(): ObjectMapper = jacksonMapperBuilder
     .build()
 
 fun erOpphavArenaOgErKlarforvisning(avtaleHendelseMelding: AvtaleHendelseMelding, rolle: Avtalerolle): Boolean {
-    if (avtaleHendelseMelding.opphav != AvtaleOpphav.ARENA) return true // Denne sjekken gjelder kun for opphav Arena (de skjules for arbeidsgiver)
+    if (avtaleHendelseMelding.opphav != AvtaleOpphav.ARENA) return true // Denn e sjekken gjelder kun for opphav Arena (de skjules for arbeidsgiver)
+    if (avtaleHendelseMelding.avtaleInngått != null) return true // Avtale er inngått, vis uansett for alle roller
 
     // DELTAKER
     if (rolle == Avtalerolle.DELTAKER) {
@@ -51,7 +52,7 @@ fun erOpphavArenaOgErKlarforvisning(avtaleHendelseMelding: AvtaleHendelseMelding
     }
     // ARBEIDSGIVER
 
-    val påkrevdeFelter = mapOf(
+    val påkrevdeMentorFelter = mapOf(
         "deltakerFornavn" to avtaleHendelseMelding.deltakerFornavn,
         "deltakerEtternavn" to avtaleHendelseMelding.deltakerEtternavn,
         "deltakerTlf" to avtaleHendelseMelding.deltakerTlf,
@@ -84,7 +85,7 @@ fun erOpphavArenaOgErKlarforvisning(avtaleHendelseMelding: AvtaleHendelseMelding
         "familietilknytningForklaring" to avtaleHendelseMelding.familietilknytningForklaring,
     )
 
-    val tommefelter = påkrevdeFelter
+    val tommefelter = påkrevdeMentorFelter
         .filter { (key, value) -> erTom(value) }
         .keys
 

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
@@ -8,6 +8,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import de.huxhorn.sulky.ulid.ULID
+import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
+import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleOpphav
+import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleStatus
+import no.nav.tiltak.tiltaknotifikasjon.avtale.Avtalerolle
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -33,3 +37,65 @@ fun jacksonMapperSomIkkeBryrSegOmEnumCase(): ObjectMapper = jacksonMapperBuilder
     .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     .build()
+
+fun mentorAvtaleErKlarForVisningForEksterne(avtaleHendelseMelding: AvtaleHendelseMelding, rolle: Avtalerolle): Boolean {
+    // DELTAKER
+    if (rolle == Avtalerolle.DELTAKER) {
+        // Avtalestatus Påbegynt betyr at ikke alle felter er fylt ut enda.
+        return avtaleHendelseMelding.avtaleStatus != AvtaleStatus.PÅBEGYNT
+    }
+    if (rolle != Avtalerolle.ARBEIDSGIVER) {
+        throw IllegalArgumentException("Skal ikke brukes for rolle: $rolle")
+    }
+    // ARBEIDSGIVER
+    if (avtaleHendelseMelding.opphav != AvtaleOpphav.ARENA) return true // Denne sjekken gjelder kun for opphav Arena (de skjules for arbeidsgiver)
+
+    val påkrevdeFelter = mapOf(
+        "deltakerFornavn" to avtaleHendelseMelding.deltakerFornavn,
+        "deltakerEtternavn" to avtaleHendelseMelding.deltakerEtternavn,
+        "deltakerTlf" to avtaleHendelseMelding.deltakerTlf,
+        "bedriftNavn" to avtaleHendelseMelding.bedriftNavn,
+        "arbeidsgiverFornavn" to avtaleHendelseMelding.arbeidsgiverFornavn,
+        "arbeidsgiverEtternavn" to avtaleHendelseMelding.arbeidsgiverEtternavn,
+        "arbeidsgiverTlf" to avtaleHendelseMelding.arbeidsgiverTlf,
+        "veilederFornavn" to avtaleHendelseMelding.veilederFornavn,
+        "veilederEtternavn" to avtaleHendelseMelding.veilederEtternavn,
+        "veilederTlf" to avtaleHendelseMelding.veilederTlf,
+        "startDato" to avtaleHendelseMelding.startDato,
+        "sluttDato" to avtaleHendelseMelding.sluttDato,
+        "oppfolging" to avtaleHendelseMelding.oppfolging,
+        "tilrettelegging" to avtaleHendelseMelding.tilrettelegging,
+        "mentorFornavn" to avtaleHendelseMelding.mentorFornavn,
+        "mentorEtternavn" to avtaleHendelseMelding.mentorEtternavn,
+        "mentorOppgaver" to avtaleHendelseMelding.mentorOppgaver,
+        "mentorAntallTimer" to avtaleHendelseMelding.mentorAntallTimer,
+        "mentorTimelonn" to avtaleHendelseMelding.mentorTimelonn,
+        "mentorTlf" to avtaleHendelseMelding.mentorTlf,
+        // Tilskuddsperiode-felter (tidligere bak MentorTilskuddsperioderToggle)
+        "arbeidsgiverKontonummer" to avtaleHendelseMelding.arbeidsgiverKontonummer,
+        "feriepengesats" to avtaleHendelseMelding.feriepengesats,
+        "otpSats" to avtaleHendelseMelding.otpSats,
+        "arbeidsgiveravgift" to avtaleHendelseMelding.arbeidsgiveravgift,
+        "mentorValgtLonnstype" to avtaleHendelseMelding.mentorValgtLonnstype,
+        "mentorValgtLonnstypeBelop" to avtaleHendelseMelding.mentorValgtLonnstypeBelop,
+        // Familietilknytning
+        "harFamilietilknytning" to avtaleHendelseMelding.harFamilietilknytning,
+        "familietilknytningForklaring" to avtaleHendelseMelding.familietilknytningForklaring,
+    )
+
+    val tommefelter = påkrevdeFelter
+        .filter { (key, value) -> erTom(value) }
+        .keys
+
+    // Alt er fylt ut, eller kun familietilknytning-felter mangler
+    return tommefelter.all { it == "harFamilietilknytning" || it == "familietilknytningForklaring" }
+}
+
+private fun erTom(verdi: Any?): Boolean {
+    return when (verdi) {
+        null -> true
+        is String -> verdi.isEmpty()
+        is Collection<*> -> verdi.isEmpty()
+        else -> false
+    }
+}

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
@@ -38,7 +38,9 @@ fun jacksonMapperSomIkkeBryrSegOmEnumCase(): ObjectMapper = jacksonMapperBuilder
     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     .build()
 
-fun mentorAvtaleErKlarForVisningForEksterne(avtaleHendelseMelding: AvtaleHendelseMelding, rolle: Avtalerolle): Boolean {
+fun erOpphavArenaOgErKlarforvisning(avtaleHendelseMelding: AvtaleHendelseMelding, rolle: Avtalerolle): Boolean {
+    if (avtaleHendelseMelding.opphav != AvtaleOpphav.ARENA) return true // Denne sjekken gjelder kun for opphav Arena (de skjules for arbeidsgiver)
+
     // DELTAKER
     if (rolle == Avtalerolle.DELTAKER) {
         // Avtalestatus Påbegynt betyr at ikke alle felter er fylt ut enda.
@@ -48,7 +50,6 @@ fun mentorAvtaleErKlarForVisningForEksterne(avtaleHendelseMelding: AvtaleHendels
         throw IllegalArgumentException("Skal ikke brukes for rolle: $rolle")
     }
     // ARBEIDSGIVER
-    if (avtaleHendelseMelding.opphav != AvtaleOpphav.ARENA) return true // Denne sjekken gjelder kun for opphav Arena (de skjules for arbeidsgiver)
 
     val påkrevdeFelter = mapOf(
         "deltakerFornavn" to avtaleHendelseMelding.deltakerFornavn,


### PR DESCRIPTION
Min forklaring først, så kommer copilot sin.

Endret slik at vi oppretter oppgave og beskjed for arbeidsgiver først når den er "klar for visning" som den blir når alt utenom enten familietilknytning eller familietilknytningforaklaring er fylt ut.
For deltaker har jeg tenkt at det er dekkende å sjekke om avtalestatusen er Påbegynt, da mangler man å fylle ut noe.

--------------------------------------------------------------------------------------------

