### PR TITLE
Fikse problemer med kafka-konsument

### DIFF
--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -59,6 +59,8 @@ class AvtaleHendelseConsumer(
     fun behandleBrukernotifikasjon(avtaleHendelse: String) {
         try {
             val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
+            MDC.put("avtaleHendelseType", melding.hendelseType.toString())
+            MDC.put("avtaleStatus", melding.avtaleStatus.toString())
             if (!sjekkOmAvtaleFraArenaSkalBehandles(melding)) return
             brukernotifikasjonService.behandleAvtaleHendelseMelding(melding)
         } catch (e: Exception) {
@@ -71,12 +73,17 @@ class AvtaleHendelseConsumer(
             )
             brukernotifikasjonRepository.save(brukernotifikasjon)
             log.error("Error parsing AvtaleHendelseMelding: ${brukernotifikasjon.id}", e)
+        } finally {
+            MDC.remove("avtaleHendelseType")
+            MDC.remove("avtaleStatus")
         }
     }
 
     fun behandleArbeidsgivernotifikasjon(avtaleHendelse: String) {
         try {
             val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
+            MDC.put("avtaleHendelseType", melding.hendelseType.toString())
+            MDC.put("avtaleStatus", melding.avtaleStatus.toString())
             if (!skalArbeidsgivernotifikasjonBehanldes(melding)) return
             arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(melding)
         } catch (e: Exception) {
@@ -89,6 +96,9 @@ class AvtaleHendelseConsumer(
             )
             arbeidsgivernotifikasjonRepository.save(arbeidsgivernotifikasjon)
             log.error("Error parsing AvtaleHendelseMelding for arbeidsgivernotifikasjon: ${arbeidsgivernotifikasjon.id}", e)
+        } finally {
+            MDC.remove("avtaleHendelseType")
+            MDC.remove("avtaleStatus")
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -16,7 +16,9 @@ import no.nav.tiltak.tiltaknotifikasjon.persondata.PersondataService
 import no.nav.tiltak.tiltaknotifikasjon.utils.erOpphavArenaOgErKlarforvisning
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
 import no.nav.tiltak.tiltaknotifikasjon.utils.ulid
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.context.annotation.Profile
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Component
@@ -35,9 +37,23 @@ class AvtaleHendelseConsumer(
     private val log = LoggerFactory.getLogger(javaClass)
 
     @KafkaListener(topics = [Topics.AVTALE_HENDELSE_COMPACT])
-    fun nyAvtaleHendelse(avtaleHendelse: String) {
-        behandleBrukernotifikasjon(avtaleHendelse)
-        behandleArbeidsgivernotifikasjon(avtaleHendelse)
+    fun nyAvtaleHendelse(melding: ConsumerRecord<String, String>) {
+        try {
+            val startTidspunkt = System.currentTimeMillis()
+            MDC.put("avtaleId", melding.key())
+            MDC.put("kafkaOffset", melding.offset().toString())
+
+            val avtaleHendelsemelding = melding.value()
+            behandleBrukernotifikasjon(avtaleHendelsemelding)
+            behandleArbeidsgivernotifikasjon(avtaleHendelsemelding)
+            val sluttTidspunkt = System.currentTimeMillis()
+            log.atInfo()
+                .addKeyValue("behandlingstidMs", sluttTidspunkt - startTidspunkt)
+                .log("Behandlet kafkamelding ${melding.offset()} på ${sluttTidspunkt - startTidspunkt} ms");
+        } finally {
+            MDC.remove("avtaleId")
+            MDC.remove("kafkaOffset")
+        }
     }
 
     fun behandleBrukernotifikasjon(avtaleHendelse: String) {
@@ -45,7 +61,6 @@ class AvtaleHendelseConsumer(
             val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
             if (!sjekkOmAvtaleFraArenaSkalBehandles(melding)) return
             brukernotifikasjonService.behandleAvtaleHendelseMelding(melding)
-
         } catch (e: Exception) {
             val brukernotifikasjon = Brukernotifikasjon(
                 id = ulid(),
@@ -78,8 +93,7 @@ class AvtaleHendelseConsumer(
     }
 
     private fun sjekkOmAvtaleFraArenaSkalBehandles(avtaleHendelse: AvtaleHendelseMelding): Boolean {
-        if (!erOpphavArenaOgErKlarforvisning(avtaleHendelse, Avtalerolle.DELTAKER)) return false
-        return true
+        return erOpphavArenaOgErKlarforvisning(avtaleHendelse, Avtalerolle.DELTAKER)
     }
 
     private fun skalArbeidsgivernotifikasjonBehanldes(avtaleHendelsemelding: AvtaleHendelseMelding): Boolean {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,7 @@ spring:
     consumer:
       group-id: "tiltak-notifikasjon-1"
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-
+value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     url: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}"
     hikari:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
       group-id: "tiltak-notifikasjon-1"
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      max-poll-records: 1
+      max-poll-interval: "PT30S"
+
   datasource:
     url: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}"
     hikari:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,8 +20,6 @@ spring:
       group-id: "tiltak-notifikasjon-1"
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      max-poll-records: 1
-      max-poll-interval: "PT30S"
 
   datasource:
     url: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
     consumer:
       group-id: "tiltak-notifikasjon-1"
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   datasource:
     url: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}"
     hikari:


### PR DESCRIPTION
Konsumenten timer ut når den behandler meldinger, som kan indikere at når den mottar for mange meldinger på en gang så vil den slite med å behandle de innenfor "poll-interval"-vinduet.

Reduserer antall meldinger som behandles på en gang til 1, og setter vinduet per melding til 30 sekunder.