### PR TITLE
fix. hent en mindre batch + lenger poll interval for kafka

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,9 @@ spring:
       group-id: "tiltak-notifikasjon-1"
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      properties:
+        max.poll.records: 10
+        max.poll.interval.ms: 600000
   datasource:
     url: "jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_DATABASE}?user=${DB_USERNAME}&password=${DB_PASSWORD}"
     hikari:


### PR DESCRIPTION
* Dette er for å ikke overlempe systemet når vi sender en stor batch med endringer på avtale-hendelse.
Ved store batcher på feks statusendringer så timer kafka ut.