### PR TITLE
fix. jsonb og mikrooptimalisering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,10 @@
 									<key>defaultNameCase</key>
 									<value>lower</value>
 								</property>
+								<property>
+									<key>parseDialect</key>
+									<value>POSTGRES</value>
+								</property>
 							</properties>
 						</database>
 						<target>

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonService.kt
@@ -2,7 +2,6 @@ package no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon
 
 import com.expediagroup.graphql.client.spring.GraphQLWebClient
 import com.expediagroup.graphql.client.types.GraphQLClientResponse
-import com.fasterxml.jackson.module.kotlin.readValue
 import kotlinx.coroutines.runBlocking
 import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.graphql.generated.*
 import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.graphql.generated.enums.OppgaveTilstand
@@ -428,10 +427,7 @@ class ArbeidsgiverNotifikasjonService(
                     log.error("AG: Fant ikke SAK i DB for sletting. grupperingsId: ${softDeleteSakQuery.variables.grupperingsid}")
                 }
                 // Sett andre notifikasjoner også til slettet. Fager skal ha cascade på soft-delete av sak.
-                arbeidsgivernotifikasjonRepository.findAllbyAvtaleId(avtaleId).filter { it.type == ArbeidsgivernotifikasjonType.Beskjed || it.type == ArbeidsgivernotifikasjonType.Oppgave }.forEach {
-                    it.status = ArbeidsgivernotifikasjonStatus.SLETTET
-                    arbeidsgivernotifikasjonRepository.save(it)
-                }
+                arbeidsgivernotifikasjonRepository.settBeskjederOgOppgaverTilSlettet(avtaleId)
                 return@runBlocking true
 
             } else if (resultat is SakFinnesIkke) {
@@ -593,17 +589,16 @@ class ArbeidsgiverNotifikasjonService(
     }
 
     fun finnesDuplikatMelding(avtaleHendelse: AvtaleHendelseMelding): Boolean {
-        // Sjekker om det finnes behandlede avtaleHendelser i basen som har likt endret tildspunt som den som kommer inn. IDEMPOTENCE-SJEKK
-        arbeidsgivernotifikasjonRepository.findAllbyAvtaleId(avtaleHendelse.avtaleId.toString()).forEach {
-            if (it.status != ArbeidsgivernotifikasjonStatus.SLETTET) {
-                val melding: AvtaleHendelseMelding = jacksonMapper().readValue(it.avtaleMeldingJson)
-                if (melding.sistEndret == avtaleHendelse.sistEndret && melding.hendelseType == avtaleHendelse.hendelseType) {
-                    log.warn("AG: Fant en brukernotifikasjon med samme hendelsetype og sistEndret tidspunkt som allerede er behandlet, avtaleId: ${avtaleHendelse.avtaleId}")
-                    return true
-                }
-            }
+        // Sjekker om det finnes behandlede avtaleHendelser i basen som har likt endret tidspunkt som den som kommer inn. IDEMPOTENCE-SJEKK
+        val erDuplikat = arbeidsgivernotifikasjonRepository.finnesDuplikatMelding(
+            avtaleId = avtaleHendelse.avtaleId.toString(),
+            sistEndret = avtaleHendelse.sistEndret.toString(),
+            hendelseType = avtaleHendelse.hendelseType.name
+        )
+        if (erDuplikat) {
+            log.warn("AG: Fant en brukernotifikasjon med samme hendelsetype og sistEndret tidspunkt som allerede er behandlet, avtaleId: ${avtaleHendelse.avtaleId}")
         }
-        return false
+        return erDuplikat
     }
 
 

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/Arbeidsgivernotifikasjon.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/Arbeidsgivernotifikasjon.kt
@@ -53,15 +53,14 @@ enum class Varslingsformål {
     KONTAKTINFORMASJON_ENDRET,
 }
 
+private fun Arbeidsgivernotifikasjon.parsedAvtaleHendelse(): AvtaleHendelseMelding =
+    jacksonMapper().readValue(this.avtaleMeldingJson)
+
 fun Arbeidsgivernotifikasjon.sendtSms(): Boolean {
-     val avtaleHendelseMelding: AvtaleHendelseMelding = jacksonMapper().readValue(this.avtaleMeldingJson)
-     return avtaleHendelseMelding.hendelseType.skalSendeSmsTilArbeidsgiver() && avtaleHendelseMelding.erArbeidsgiversTlfGyldigNorskMobilnr()
+     val melding = parsedAvtaleHendelse()
+     return melding.hendelseType.skalSendeSmsTilArbeidsgiver() && melding.erArbeidsgiversTlfGyldigNorskMobilnr()
 }
 fun Arbeidsgivernotifikasjon.mottakerTlf(): String? {
-    val avtaleHendelseMelding: AvtaleHendelseMelding = jacksonMapper().readValue(this.avtaleMeldingJson)
-    if (avtaleHendelseMelding.hendelseType.skalSendeSmsTilArbeidsgiver()) {
-        return avtaleHendelseMelding.arbeidsgiverTlf
-    } else {
-        return null
-    }
+    val melding = parsedAvtaleHendelse()
+    return if (melding.hendelseType.skalSendeSmsTilArbeidsgiver()) melding.arbeidsgiverTlf else null
 }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgivernotifikasjonRepository.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgivernotifikasjonRepository.kt
@@ -4,6 +4,8 @@ import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.Arbeidsgivernotifikasjon.Companion.ARBEIDSGIVERNOTIFIKASJON
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.records.ArbeidsgivernotifikasjonRecord
 import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.impl.DSL
 import org.springframework.stereotype.Component
 import java.time.ZoneOffset
 
@@ -58,8 +60,8 @@ class ArbeidsgivernotifikasjonRepository(val dsl: DSLContext) {
     private fun mapToArbeidsgivernotifikasjon(record: ArbeidsgivernotifikasjonRecord): Arbeidsgivernotifikasjon {
         return Arbeidsgivernotifikasjon(
             id = record.id,
-            avtaleMeldingJson = record.avtaleMeldingJson,
-            arbeidsgivernotifikasjonJson = record.arbeidsgivernotifikasjonJson,
+            avtaleMeldingJson = record.avtaleMeldingJson.data(),
+            arbeidsgivernotifikasjonJson = record.arbeidsgivernotifikasjonJson?.data(),
             type = if (record.type != null) ArbeidsgivernotifikasjonType.valueOf(record.type!!) else null,
             status = enumValueOf<ArbeidsgivernotifikasjonStatus>(record.status),
             bedriftNr = record.bedriftNr,
@@ -79,8 +81,8 @@ class ArbeidsgivernotifikasjonRepository(val dsl: DSLContext) {
     private fun mapToDatabaseRecord(arbeidsgivernotifikasjon: Arbeidsgivernotifikasjon): ArbeidsgivernotifikasjonRecord {
         return ArbeidsgivernotifikasjonRecord(
             id = arbeidsgivernotifikasjon.id,
-            avtaleMeldingJson = arbeidsgivernotifikasjon.avtaleMeldingJson,
-            arbeidsgivernotifikasjonJson = arbeidsgivernotifikasjon.arbeidsgivernotifikasjonJson,
+            avtaleMeldingJson = JSON.json(arbeidsgivernotifikasjon.avtaleMeldingJson),
+            arbeidsgivernotifikasjonJson = arbeidsgivernotifikasjon.arbeidsgivernotifikasjonJson?.let { JSON.json(it) },
             type = arbeidsgivernotifikasjon.type?.name,
             status = arbeidsgivernotifikasjon.status.name,
             bedriftNr = arbeidsgivernotifikasjon.bedriftNr,
@@ -135,5 +137,26 @@ class ArbeidsgivernotifikasjonRepository(val dsl: DSLContext) {
             ?.map { mapToArbeidsgivernotifikasjon(it as ArbeidsgivernotifikasjonRecord) }
     }
 
+    fun finnesDuplikatMelding(avtaleId: String, sistEndret: String, hendelseType: String): Boolean {
+        return dsl.fetchExists(
+            dsl.selectOne()
+                .from(ARBEIDSGIVERNOTIFIKASJON)
+                .where(ARBEIDSGIVERNOTIFIKASJON.AVTALE_ID.eq(avtaleId))
+                .and(ARBEIDSGIVERNOTIFIKASJON.STATUS.ne(ArbeidsgivernotifikasjonStatus.SLETTET.name))
+                .and(DSL.field("avtale_melding_json->>'sistEndret'", String::class.java).eq(sistEndret))
+                .and(DSL.field("avtale_melding_json->>'hendelseType'", String::class.java).eq(hendelseType))
+        )
+    }
+
+    fun settBeskjederOgOppgaverTilSlettet(avtaleId: String) {
+        dsl.update(ARBEIDSGIVERNOTIFIKASJON)
+            .set(ARBEIDSGIVERNOTIFIKASJON.STATUS, ArbeidsgivernotifikasjonStatus.SLETTET.name)
+            .where(ARBEIDSGIVERNOTIFIKASJON.AVTALE_ID.eq(avtaleId))
+            .and(
+                ARBEIDSGIVERNOTIFIKASJON.TYPE.eq(ArbeidsgivernotifikasjonType.Beskjed.name)
+                    .or(ARBEIDSGIVERNOTIFIKASJON.TYPE.eq(ArbeidsgivernotifikasjonType.Oppgave.name))
+            )
+            .execute()
+    }
 
 }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/brukernotifikasjoner/BrukernotifikasjonRepository.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/brukernotifikasjoner/BrukernotifikasjonRepository.kt
@@ -5,9 +5,9 @@ import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.Brukernotifi
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.records.BrukernotifikasjonRecord
 import no.nav.tiltak.tiltaknotifikasjon.kafka.EksternStatusOppdatertStatus
 import org.jooq.DSLContext
+import org.jooq.JSON
+import org.jooq.impl.DSL
 import org.springframework.stereotype.Component
-import java.time.Instant
-import java.time.OffsetDateTime
 import java.time.ZoneOffset
 
 @Component
@@ -78,12 +78,33 @@ class BrukernotifikasjonRepository(val dsl: DSLContext) {
         dsl.deleteFrom(BRUKERNOTIFIKASJON).execute()
     }
 
+    fun finnesAktivOppgaveMedFormål(avtaleId: String, varslingsformål: Varslingsformål): Boolean {
+        return dsl.fetchExists(
+            dsl.selectOne()
+                .from(BRUKERNOTIFIKASJON)
+                .where(BRUKERNOTIFIKASJON.AVTALE_ID.eq(avtaleId))
+                .and(BRUKERNOTIFIKASJON.TYPE.eq(BrukernotifikasjonType.Oppgave.name))
+                .and(BRUKERNOTIFIKASJON.VARSLINGSFORMÅL.eq(varslingsformål.name))
+                .and(BRUKERNOTIFIKASJON.STATUS.ne(BrukernotifikasjonStatus.INAKTIVERT.name))
+        )
+    }
+
+    fun finnesDuplikatMelding(avtaleId: String, sistEndret: String, hendelseType: String): Boolean {
+        return dsl.fetchExists(
+            dsl.selectOne()
+                .from(BRUKERNOTIFIKASJON)
+                .where(BRUKERNOTIFIKASJON.AVTALE_ID.eq(avtaleId))
+                .and(BRUKERNOTIFIKASJON.STATUS.ne(BrukernotifikasjonStatus.INAKTIVERT.name))
+                .and(DSL.field("avtale_melding_json->>'sistEndret'", String::class.java).eq(sistEndret))
+                .and(DSL.field("avtale_melding_json->>'hendelseType'", String::class.java).eq(hendelseType))
+        )
+    }
 
     fun mapToBrukernotifikasjon(record: BrukernotifikasjonRecord): Brukernotifikasjon {
         return Brukernotifikasjon(
             id = record.id,
-            avtaleMeldingJson = record.avtaleMeldingJson,
-            minSideJson = record.minSideJson,
+            avtaleMeldingJson = record.avtaleMeldingJson.data(),
+            minSideJson = record.minSideJson?.data(),
             type = if (record.type != null) enumValueOf<BrukernotifikasjonType>(record.type!!) else null,
             status = enumValueOf<BrukernotifikasjonStatus>(record.status),
             feilmelding = record.feilmelding,
@@ -103,8 +124,8 @@ class BrukernotifikasjonRepository(val dsl: DSLContext) {
     private fun mapToRecord(brukernotifikasjon: Brukernotifikasjon): BrukernotifikasjonRecord {
         return BrukernotifikasjonRecord(
             id = brukernotifikasjon.id,
-            avtaleMeldingJson = brukernotifikasjon.avtaleMeldingJson,
-            minSideJson = brukernotifikasjon.minSideJson,
+            avtaleMeldingJson = JSON.json(brukernotifikasjon.avtaleMeldingJson),
+            minSideJson = brukernotifikasjon.minSideJson?.let { JSON.json(it) },
             type = brukernotifikasjon.type?.name,
             status = brukernotifikasjon.status.name,
             feilmelding = brukernotifikasjon.feilmelding,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/brukernotifikasjoner/BrukernotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/brukernotifikasjoner/BrukernotifikasjonService.kt
@@ -1,6 +1,5 @@
 package no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
 import no.nav.tiltak.tiltaknotifikasjon.kafka.MinSideProdusent
@@ -117,27 +116,23 @@ class BrukernotifikasjonService(val minSideProdusent: MinSideProdusent, val bruk
     }
 
     fun sjekkOmDetFinnesAktiveOppgaverPåAvtaleMedFormål(avtaleHendelse: AvtaleHendelseMelding, varslingsformål: Varslingsformål): Boolean {
-        brukernotifikasjonRepository.findAllByAvtaleIdAndType(avtaleHendelse.avtaleId.toString(), BrukernotifikasjonType.Oppgave).filter { it.varslingsformål == varslingsformål }.forEach {
-            if (it.status != BrukernotifikasjonStatus.INAKTIVERT) {
-                // Finnes en oppgave på avtalen som ikke er inaktivert
-                log.info("Fant allerede en aktiv brukernotifikasjon oppgave ${it.id} på avtaleId: ${avtaleHendelse.avtaleId} med formål: $varslingsformål")
-                return true
-            }
+        val finnes = brukernotifikasjonRepository.finnesAktivOppgaveMedFormål(avtaleHendelse.avtaleId.toString(), varslingsformål)
+        if (finnes) {
+            log.info("Fant allerede en aktiv brukernotifikasjon oppgave på avtaleId: ${avtaleHendelse.avtaleId} med formål: $varslingsformål")
         }
-        return false
+        return finnes
     }
     fun finnesDuplikatMelding(avtaleHendelse: AvtaleHendelseMelding): Boolean {
-        // Sjekker om det finnes behandlede avtaleHendelser i basen som har likt endret tildspunt som den som kommer inn. Bør ikke skje.
-        brukernotifikasjonRepository.findAllbyAvtaleId(avtaleHendelse.avtaleId.toString()).forEach {
-            if (it.status != BrukernotifikasjonStatus.INAKTIVERT) {
-                val melding: AvtaleHendelseMelding = jacksonMapper().readValue(it.avtaleMeldingJson)
-                if (melding.sistEndret == avtaleHendelse.sistEndret && melding.hendelseType == avtaleHendelse.hendelseType) {
-                    log.warn("Fant en brukernotifikasjon med samme hendelsetype og sistEndret tidspunkt som allerede er behandlet, avtaleId: ${avtaleHendelse.avtaleId}")
-                    return true
-                }
-            }
+        // Sjekker om det finnes behandlede avtaleHendelser i basen som har likt endret tidspunkt som den som kommer inn. Bør ikke skje.
+        val erDuplikat = brukernotifikasjonRepository.finnesDuplikatMelding(
+            avtaleId = avtaleHendelse.avtaleId.toString(),
+            sistEndret = avtaleHendelse.sistEndret.toString(),
+            hendelseType = avtaleHendelse.hendelseType.name
+        )
+        if (erDuplikat) {
+            log.warn("Fant en brukernotifikasjon med samme hendelsetype og sistEndret tidspunkt som allerede er behandlet, avtaleId: ${avtaleHendelse.avtaleId}")
         }
-        return false
+        return erDuplikat
     }
 
     fun nyBrukernotifikasjon(avtaleHendelse: AvtaleHendelseMelding, type: BrukernotifikasjonType, varslingsformål: Varslingsformål?, oppgaveIdOgJson: Pair<String, String>): Brukernotifikasjon =

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -43,9 +43,13 @@ class AvtaleHendelseConsumer(
             MDC.put("avtaleId", melding.key())
             MDC.put("kafkaOffset", melding.offset().toString())
 
-            val avtaleHendelsemelding = melding.value()
-            behandleBrukernotifikasjon(avtaleHendelsemelding)
-            behandleArbeidsgivernotifikasjon(avtaleHendelsemelding)
+            val avtaleHendelseJson = melding.value()
+            val avtaleHendelseMelding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelseJson)
+            MDC.put("avtaleHendelseType", avtaleHendelseMelding.hendelseType.toString())
+            MDC.put("avtaleStatus", avtaleHendelseMelding.avtaleStatus.toString())
+
+            behandleBrukernotifikasjon(avtaleHendelseJson, avtaleHendelseMelding)
+            behandleArbeidsgivernotifikasjon(avtaleHendelseJson, avtaleHendelseMelding)
             val sluttTidspunkt = System.currentTimeMillis()
             log.atInfo()
                 .addKeyValue("behandlingstidMs", sluttTidspunkt - startTidspunkt)
@@ -53,52 +57,42 @@ class AvtaleHendelseConsumer(
         } finally {
             MDC.remove("avtaleId")
             MDC.remove("kafkaOffset")
+            MDC.remove("avtaleHendelseType")
+            MDC.remove("avtaleStatus")
         }
     }
 
-    fun behandleBrukernotifikasjon(avtaleHendelse: String) {
+    fun behandleBrukernotifikasjon(avtaleHendelseJson: String, melding: AvtaleHendelseMelding) {
         try {
-            val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
-            MDC.put("avtaleHendelseType", melding.hendelseType.toString())
-            MDC.put("avtaleStatus", melding.avtaleStatus.toString())
             if (!sjekkOmAvtaleFraArenaSkalBehandles(melding)) return
             brukernotifikasjonService.behandleAvtaleHendelseMelding(melding)
         } catch (e: Exception) {
             val brukernotifikasjon = Brukernotifikasjon(
                 id = ulid(),
-                avtaleMeldingJson = avtaleHendelse,
+                avtaleMeldingJson = avtaleHendelseJson,
                 status = BrukernotifikasjonStatus.FEILET_VED_BEHANDLING,
                 opprettet = Instant.now(),
                 feilmelding = e.message
             )
             brukernotifikasjonRepository.save(brukernotifikasjon)
             log.error("Error parsing AvtaleHendelseMelding: ${brukernotifikasjon.id}", e)
-        } finally {
-            MDC.remove("avtaleHendelseType")
-            MDC.remove("avtaleStatus")
         }
     }
 
-    fun behandleArbeidsgivernotifikasjon(avtaleHendelse: String) {
+    fun behandleArbeidsgivernotifikasjon(avtaleHendelseJson: String, melding: AvtaleHendelseMelding) {
         try {
-            val melding: AvtaleHendelseMelding = mapper.readValue(avtaleHendelse)
-            MDC.put("avtaleHendelseType", melding.hendelseType.toString())
-            MDC.put("avtaleStatus", melding.avtaleStatus.toString())
             if (!skalArbeidsgivernotifikasjonBehanldes(melding)) return
             arbeidsgiverNotifikasjonService.behandleAvtaleHendelseMelding(melding)
         } catch (e: Exception) {
             val arbeidsgivernotifikasjon = Arbeidsgivernotifikasjon(
                 id = ulid(),
-                avtaleMeldingJson = avtaleHendelse,
+                avtaleMeldingJson = avtaleHendelseJson,
                 status = ArbeidsgivernotifikasjonStatus.FEILET_VED_BEHANDLING,
                 opprettetTidspunkt = Instant.now(),
                 feilmelding = e.message
             )
             arbeidsgivernotifikasjonRepository.save(arbeidsgivernotifikasjon)
             log.error("Error parsing AvtaleHendelseMelding for arbeidsgivernotifikasjon: ${arbeidsgivernotifikasjon.id}", e)
-        } finally {
-            MDC.remove("avtaleHendelseType")
-            MDC.remove("avtaleStatus")
         }
     }
 

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/utils/Utils.kt
@@ -18,10 +18,13 @@ import java.time.format.DateTimeFormatter
 private val ulidGenerator = ULID()
 fun ulid(): String = ulidGenerator.nextULID()
 
-fun jacksonMapper(): ObjectMapper = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+private val cachedJacksonMapper: ObjectMapper = jacksonObjectMapper()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     .registerModule(JavaTimeModule())
     .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     .configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
+
+fun jacksonMapper(): ObjectMapper = cachedJacksonMapper
 
 fun norskDatoFormat(dato: LocalDate) = dato.format(DateTimeFormatter.ofPattern("dd.MM.yyyy"))
 

--- a/src/main/resources/db/migration/V9__jsonb.sql
+++ b/src/main/resources/db/migration/V9__jsonb.sql
@@ -1,0 +1,29 @@
+-- Endre _json-kolonner fra varchar til jsonb.
+-- Bruker add/drop/rename i stedet for ALTER COLUMN TYPE jsonb USING fordi
+-- jOOQ 3.18 sin DDLDatabase-parser ikke støtter USING-klausulen.
+
+-- brukernotifikasjon: avtale_melding_json varchar -> jsonb (NOT NULL)
+ALTER TABLE brukernotifikasjon ADD COLUMN avtale_melding_jsonb jsonb;
+UPDATE brukernotifikasjon SET avtale_melding_jsonb = avtale_melding_json::jsonb;
+ALTER TABLE brukernotifikasjon DROP COLUMN avtale_melding_json;
+ALTER TABLE brukernotifikasjon RENAME COLUMN avtale_melding_jsonb TO avtale_melding_json;
+ALTER TABLE brukernotifikasjon ALTER COLUMN avtale_melding_json SET NOT NULL;
+
+-- brukernotifikasjon: min_side_json varchar -> jsonb (nullable)
+ALTER TABLE brukernotifikasjon ADD COLUMN min_side_jsonb jsonb;
+UPDATE brukernotifikasjon SET min_side_jsonb = min_side_json::jsonb;
+ALTER TABLE brukernotifikasjon DROP COLUMN min_side_json;
+ALTER TABLE brukernotifikasjon RENAME COLUMN min_side_jsonb TO min_side_json;
+
+-- arbeidsgivernotifikasjon: avtale_melding_json varchar -> jsonb (NOT NULL)
+ALTER TABLE arbeidsgivernotifikasjon ADD COLUMN avtale_melding_jsonb jsonb;
+UPDATE arbeidsgivernotifikasjon SET avtale_melding_jsonb = avtale_melding_json::jsonb;
+ALTER TABLE arbeidsgivernotifikasjon DROP COLUMN avtale_melding_json;
+ALTER TABLE arbeidsgivernotifikasjon RENAME COLUMN avtale_melding_jsonb TO avtale_melding_json;
+ALTER TABLE arbeidsgivernotifikasjon ALTER COLUMN avtale_melding_json SET NOT NULL;
+
+-- arbeidsgivernotifikasjon: arbeidsgivernotifikasjon_json varchar -> jsonb (nullable)
+ALTER TABLE arbeidsgivernotifikasjon ADD COLUMN arbeidsgivernotifikasjon_jsonb jsonb;
+UPDATE arbeidsgivernotifikasjon SET arbeidsgivernotifikasjon_jsonb = arbeidsgivernotifikasjon_json::jsonb;
+ALTER TABLE arbeidsgivernotifikasjon DROP COLUMN arbeidsgivernotifikasjon_json;
+ALTER TABLE arbeidsgivernotifikasjon RENAME COLUMN arbeidsgivernotifikasjon_jsonb TO arbeidsgivernotifikasjon_json;


### PR DESCRIPTION
1. jacksonMapper() → cached singleton Before: Every call to jacksonMapper() created a new ObjectMapper, registered modules, configured features. Called dozens of times per Kafka message. After: One ObjectMapper created at startup, reused for all calls. ObjectMapper is thread-safe after configuration.
2. Parse Kafka message once Before: AvtaleHendelseConsumer deserialized the JSON string to AvtaleHendelseMelding twice — once in behandleBrukernotifikasjon and once in behandleArbeidsgivernotifikasjon. After: Parsed once in nyAvtaleHendelse, passed as a parameter to both handlers.
3. sendtSms() / mottakerTlf() — share deserialization Before: Both extension functions called jacksonMapper().readValue(this.avtaleMeldingJson) independently — two deserializations of the same JSON when called together in kvitteringFra(). After: Extracted a shared parsedAvtaleHendelse() helper. Each function still deserializes once when called individually, but the ObjectMapper allocation is now free thanks to optimization #1.
4. Batch UPDATE instead of fetch-all-and-save-per-record Before: softDeleteSak did findAllbyAvtaleId(avtaleId).filter { Beskjed || Oppgave }.forEach { save(it) } — N+1 queries (1 SELECT + N UPDATEs). After: settBeskjederOgOppgaverTilSlettet(avtaleId) — a single UPDATE ... WHERE avtale_id = ? AND (type = 'Beskjed' OR type = 'Oppgave').
5. Save as JSONB