### PR TITLE
concurrently stottes ikke av jooq-h2

### DIFF
--- a/src/main/resources/db/migration/V8__indekser.sql
+++ b/src/main/resources/db/migration/V8__indekser.sql
@@ -1,5 +1,5 @@
 -- Indekser på ofte brukte kolonner i spørringer
-CREATE INDEX CONCURRENTLY idx_brukernotifikasjon_avtale_id ON brukernotifikasjon (avtale_id);
-CREATE INDEX CONCURRENTLY idx_brukernotifikasjon_varsel_id ON brukernotifikasjon (varsel_id);
-CREATE INDEX CONCURRENTLY idx_arbeidsgivernotifikasjon_avtale_id ON arbeidsgivernotifikasjon (avtale_id);
-CREATE INDEX CONCURRENTLY idx_arbeidsgivernotifikasjon_response_id ON arbeidsgivernotifikasjon (response_id);
+CREATE INDEX IF NOT EXISTS idx_brukernotifikasjon_avtale_id ON brukernotifikasjon (avtale_id);
+CREATE INDEX IF NOT EXISTS idx_brukernotifikasjon_varsel_id ON brukernotifikasjon (varsel_id);
+CREATE INDEX IF NOT EXISTS idx_arbeidsgivernotifikasjon_avtale_id ON arbeidsgivernotifikasjon (avtale_id);
+CREATE INDEX IF NOT EXISTS idx_arbeidsgivernotifikasjon_response_id ON arbeidsgivernotifikasjon (response_id);


### PR DESCRIPTION
Problemet er CREATE INDEX CONCURRENTLY – jOOQ sin kode-generator bruker en in-memory H2-database for å parse SQL-migrasjonene, og H2 støtter ikke CONCURRENTLY-nøkkelordet. Det er en PostgreSQL-spesifikk feature.