### PR TITLE
Filter på hva som skal prosesserers for refusjon kontaktperson

### DIFF
--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
@@ -64,3 +64,10 @@ fun HendelseType.skalSendeSmsTilArbeidsgiver(): Boolean =
         HendelseType.OPPRETTET -> false // Dette lar seg dessverre ikke gjøre, fordi vi ikke har arbeidsgivers tlfnr på dette tidspunktet.
         else -> false
     }
+
+fun HendelseType.kanOppdatereRefusjonKontakpterson(): Boolean =
+    when (this) {
+        HendelseType.ENDRET -> true
+        HendelseType.KONTAKTINFORMASJON_ENDRET -> true
+        else -> false
+    }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
@@ -67,7 +67,6 @@ fun HendelseType.skalSendeSmsTilArbeidsgiver(): Boolean =
 
 fun HendelseType.kanOppdatereRefusjonKontaktperson(): Boolean =
     when (this) {
-        HendelseType.ENDRET -> true
-        HendelseType.KONTAKTINFORMASJON_ENDRET -> true
+        HendelseType.ENDRET, HendelseType.KONTAKTINFORMASJON_ENDRET -> true
         else -> false
     }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
@@ -65,7 +65,7 @@ fun HendelseType.skalSendeSmsTilArbeidsgiver(): Boolean =
         else -> false
     }
 
-fun HendelseType.kanOppdatereRefusjonKontakpterson(): Boolean =
+fun HendelseType.kanOppdatereRefusjonKontaktperson(): Boolean =
     when (this) {
         HendelseType.ENDRET -> true
         HendelseType.KONTAKTINFORMASJON_ENDRET -> true

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -11,7 +11,7 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.RefusjonKontakt
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.Avtalerolle
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
-import no.nav.tiltak.tiltaknotifikasjon.avtale.kanOppdatereRefusjonKontakpterson
+import no.nav.tiltak.tiltaknotifikasjon.avtale.kanOppdatereRefusjonKontaktperson
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.Brukernotifikasjon
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonRepository
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonService
@@ -115,7 +115,7 @@ class AvtaleHendelseConsumer(
         try {
             if (!unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")) return // Backfill håndteres av RefusjonKontaktpersonConsumer
             if (avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf == null) return
-            if (!avtaleHendelseMelding.hendelseType.kanOppdatereRefusjonKontakpterson()) return
+            if (!avtaleHendelseMelding.hendelseType.kanOppdatereRefusjonKontaktperson()) return
             log.info("Lagrer refusjon kontaktperson for avtale ${avtaleHendelseMelding.avtaleId}, offset $offset")
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -11,6 +11,7 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.RefusjonKontakt
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.Avtalerolle
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
+import no.nav.tiltak.tiltaknotifikasjon.avtale.kanOppdatereRefusjonKontakpterson
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.Brukernotifikasjon
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonRepository
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonService
@@ -114,6 +115,8 @@ class AvtaleHendelseConsumer(
         try {
             if (!unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")) return // Backfill håndteres av RefusjonKontaktpersonConsumer
             if (avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf == null) return
+            if (!avtaleHendelseMelding.hendelseType.kanOppdatereRefusjonKontakpterson()) return
+            log.info("Lagrer refusjon kontaktperson for avtale ${avtaleHendelseMelding.avtaleId}, offset $offset")
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,


### PR DESCRIPTION
Prosesserer og lagrer ikke refusjon kontaktperson på hendelser som er urelevante i consumeren vi skal gå over på å bruke når vi nå snart flipper toggelen.