### PR TITLE
lagrer kontaktperson for refusjon for alle avtaler

### DIFF
--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepository.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepository.kt
@@ -47,16 +47,16 @@ class ArbeidsgiverRefusjonKontaktpersonRepository(val dsl: DSLContext) {
     }
 
     private fun mapToEntitet(record: ArbeidsgiverRefusjonKontaktpersonRecord) = RefusjonKontaktpersonEntitet(
-        avtaleId = record.avtaleId!!,
+        avtaleId = record.avtaleId,
         refusjonKontaktpersonTlf = record.refusjonKontaktpersonTlf,
         arbeidsgiverOnskerOgsaVarsling = record.arbeidsgiverOnskerOgsaVarsling,
         arbeidsgiverTlf = record.arbeidsgiverTlf,
-        tiltakstype = Tiltakstype.valueOf(record.tiltakstype!!),
-        avtaleInnholdVersjon = record.avtaleInnholdVersjon!!,
-        avtaleHendelseType = HendelseType.valueOf(record.avtaleHendelseType!!),
-        avtaleHendelseSistEndret = record.avtaleHendelseSistEndret!!.toInstant(),
-        topicOffset = record.topicOffset!!,
-        innlestTidspunkt = record.innlestTidspunkt!!.toInstant(),
+        tiltakstype = Tiltakstype.valueOf(record.tiltakstype),
+        avtaleInnholdVersjon = record.avtaleInnholdVersjon,
+        avtaleHendelseType = HendelseType.valueOf(record.avtaleHendelseType),
+        avtaleHendelseSistEndret = record.avtaleHendelseSistEndret.toInstant(),
+        topicOffset = record.topicOffset,
+        innlestTidspunkt = record.innlestTidspunkt.toInstant(),
     )
 
     private fun finnIdPåEksisterende(entitet: RefusjonKontaktpersonEntitet): String? {

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepository.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepository.kt
@@ -1,6 +1,7 @@
 package no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon
 
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
+import no.nav.tiltak.tiltaknotifikasjon.avtale.Tiltakstype
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.ArbeidsgiverRefusjonKontaktperson.Companion.ARBEIDSGIVER_REFUSJON_KONTAKTPERSON
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.records.ArbeidsgiverRefusjonKontaktpersonRecord
 import no.nav.tiltak.tiltaknotifikasjon.utils.ulid
@@ -21,6 +22,8 @@ class ArbeidsgiverRefusjonKontaktpersonRepository(val dsl: DSLContext) {
             avtaleId = refusjonKontaktperson.avtaleId,
             refusjonKontaktpersonTlf = refusjonKontaktperson.refusjonKontaktpersonTlf,
             arbeidsgiverOnskerOgsaVarsling = refusjonKontaktperson.arbeidsgiverOnskerOgsaVarsling,
+            arbeidsgiverTlf = refusjonKontaktperson.arbeidsgiverTlf,
+            tiltakstype = refusjonKontaktperson.tiltakstype.name,
             avtaleInnholdVersjon = refusjonKontaktperson.avtaleInnholdVersjon,
             avtaleHendelseType = refusjonKontaktperson.avtaleHendelseType.name,
             avtaleHendelseSistEndret = refusjonKontaktperson.avtaleHendelseSistEndret.atOffset(ZoneOffset.UTC),
@@ -45,8 +48,10 @@ class ArbeidsgiverRefusjonKontaktpersonRepository(val dsl: DSLContext) {
 
     private fun mapToEntitet(record: ArbeidsgiverRefusjonKontaktpersonRecord) = RefusjonKontaktpersonEntitet(
         avtaleId = record.avtaleId!!,
-        refusjonKontaktpersonTlf = record.refusjonKontaktpersonTlf!!,
+        refusjonKontaktpersonTlf = record.refusjonKontaktpersonTlf,
         arbeidsgiverOnskerOgsaVarsling = record.arbeidsgiverOnskerOgsaVarsling,
+        arbeidsgiverTlf = record.arbeidsgiverTlf,
+        tiltakstype = Tiltakstype.valueOf(record.tiltakstype!!),
         avtaleInnholdVersjon = record.avtaleInnholdVersjon!!,
         avtaleHendelseType = HendelseType.valueOf(record.avtaleHendelseType!!),
         avtaleHendelseSistEndret = record.avtaleHendelseSistEndret!!.toInstant(),

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/RefusjonKontaktpersonEntitet.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/RefusjonKontaktpersonEntitet.kt
@@ -1,13 +1,16 @@
 package no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon
 
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
+import no.nav.tiltak.tiltaknotifikasjon.avtale.Tiltakstype
 import java.time.Instant
 import java.util.UUID
 
 data class RefusjonKontaktpersonEntitet(
     val avtaleId: UUID,
-    val refusjonKontaktpersonTlf: String,
+    val refusjonKontaktpersonTlf: String?,
     val arbeidsgiverOnskerOgsaVarsling: Boolean?,
+    val arbeidsgiverTlf: String?,
+    val tiltakstype: Tiltakstype,
     val avtaleInnholdVersjon: Int,
     val avtaleHendelseType: HendelseType,
     val avtaleHendelseSistEndret: Instant,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/RefusjonKontaktpersonEntitet.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/RefusjonKontaktpersonEntitet.kt
@@ -9,7 +9,7 @@ data class RefusjonKontaktpersonEntitet(
     val avtaleId: UUID,
     val refusjonKontaktpersonTlf: String?,
     val arbeidsgiverOnskerOgsaVarsling: Boolean?,
-    val arbeidsgiverTlf: String?,
+    val arbeidsgiverTlf: String,
     val tiltakstype: Tiltakstype,
     val avtaleInnholdVersjon: Int,
     val avtaleHendelseType: HendelseType,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -11,6 +11,7 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.RefusjonKontakt
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.Avtalerolle
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
+import no.nav.tiltak.tiltaknotifikasjon.avtale.Tiltakstype
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.Brukernotifikasjon
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonRepository
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.BrukernotifikasjonService
@@ -113,12 +114,14 @@ class AvtaleHendelseConsumer(
     fun lagreRefusjonKontaktperson(avtaleHendelseMelding: AvtaleHendelseMelding, offset: Long) {
         try {
             if (!unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")) return // Backfill håndteres av RefusjonKontaktpersonConsumer
-            if (avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf == null) return
+            if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,
-                refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson.refusjonKontaktpersonTlf,
-                arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson.ønskerVarslingOmRefusjon,
+                refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf,
+                arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson?.ønskerVarslingOmRefusjon,
+                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf,
+                tiltakstype = avtaleHendelseMelding.tiltakstype,
                 avtaleInnholdVersjon = avtaleHendelseMelding.versjon,
                 avtaleHendelseType = avtaleHendelseMelding.hendelseType,
                 avtaleHendelseSistEndret = avtaleHendelseMelding.sistEndret,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -114,8 +114,9 @@ class AvtaleHendelseConsumer(
     fun lagreRefusjonKontaktperson(avtaleHendelseMelding: AvtaleHendelseMelding, offset: Long) {
         try {
             if (!unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")) return // Backfill håndteres av RefusjonKontaktpersonConsumer
-            if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return
-            if (avtaleHendelseMelding.avtaleInngått == null) return
+            if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return // arbeidstrening har ikke økonomi
+            if (avtaleHendelseMelding.avtaleInngått == null) return  // refusjonsvarslinger har ingen nytte på ting som ikke er inngått
+            if (avtaleHendelseMelding.arbeidsgiverTlf == null) return // skal ikke kunne skje på inngått avtale
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -122,7 +122,7 @@ class AvtaleHendelseConsumer(
                 avtaleId = avtaleHendelseMelding.avtaleId,
                 refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf,
                 arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson?.ønskerVarslingOmRefusjon,
-                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf!!,
+                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf,
                 tiltakstype = avtaleHendelseMelding.tiltakstype,
                 avtaleInnholdVersjon = avtaleHendelseMelding.versjon,
                 avtaleHendelseType = avtaleHendelseMelding.hendelseType,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/AvtaleHendelseConsumer.kt
@@ -115,12 +115,13 @@ class AvtaleHendelseConsumer(
         try {
             if (!unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")) return // Backfill håndteres av RefusjonKontaktpersonConsumer
             if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return
+            if (avtaleHendelseMelding.avtaleInngått == null) return
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,
                 refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf,
                 arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson?.ønskerVarslingOmRefusjon,
-                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf,
+                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf!!,
                 tiltakstype = avtaleHendelseMelding.tiltakstype,
                 avtaleInnholdVersjon = avtaleHendelseMelding.versjon,
                 avtaleHendelseType = avtaleHendelseMelding.hendelseType,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
@@ -31,12 +31,13 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
             if (!skalBehandles()) return
             val avtaleHendelseMelding: AvtaleHendelseMelding = mapper.readValue(melding.value())
             if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return
+            if (avtaleHendelseMelding.avtaleInngått == null) return
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,
                 refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf,
                 arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson?.ønskerVarslingOmRefusjon,
-                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf,
+                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf!!,
                 tiltakstype = avtaleHendelseMelding.tiltakstype,
                 avtaleInnholdVersjon = avtaleHendelseMelding.versjon,
                 avtaleHendelseType = avtaleHendelseMelding.hendelseType,

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
@@ -28,10 +28,8 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
     )
     fun konsumer(melding: ConsumerRecord<String, String>) {
         try {
-            if (!skalBehandles()) return
             val avtaleHendelseMelding: AvtaleHendelseMelding = mapper.readValue(melding.value())
-            if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return
-            if (avtaleHendelseMelding.avtaleInngått == null) return
+            if (!skalBehandles(avtaleHendelseMelding)) return
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,
@@ -58,7 +56,10 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
         }
     }
 
-    private fun skalBehandles(): Boolean {
+    private fun skalBehandles(avtaleHendelseMelding: AvtaleHendelseMelding): Boolean {
+        if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return false // arbeidstrening har ikke økonomi
+        if (avtaleHendelseMelding.avtaleInngått == null) return false // refusjonsvarslinger har ingen nytte på ting som ikke er inngått
+        if (avtaleHendelseMelding.arbeidsgiverTlf == null) return false // skal ikke kunne skje på inngått avtale
         // Kjører backfill frem til toggle skrus på, da tar AvtaleHendelseConsumer over
         return !unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")
     }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
@@ -5,6 +5,7 @@ import io.getunleash.Unleash
 import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.ArbeidsgiverRefusjonKontaktpersonRepository
 import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.RefusjonKontaktpersonEntitet
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
+import no.nav.tiltak.tiltaknotifikasjon.avtale.Tiltakstype
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
@@ -22,20 +23,21 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
     private val antallLagret = AtomicLong(0)
 
     @KafkaListener(topics = [Topics.AVTALE_HENDELSE_COMPACT],
-        groupId = "tiltak-notifikasjon-refusjon-kontaktperson-2",
+        groupId = "tiltak-notifikasjon-refusjon-kontaktperson-3",
         properties = ["auto.offset.reset=earliest"], // Hmm, trodde ikke dette var nødvendig.. tydeligvis.
     )
     fun konsumer(melding: ConsumerRecord<String, String>) {
         try {
             if (!skalBehandles()) return
             val avtaleHendelseMelding: AvtaleHendelseMelding = mapper.readValue(melding.value())
-            if (avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf == null) return
-
+            if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return
 
             val refusjonKontaktperson = RefusjonKontaktpersonEntitet(
                 avtaleId = avtaleHendelseMelding.avtaleId,
-                refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson.refusjonKontaktpersonTlf,
-                arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson.ønskerVarslingOmRefusjon,
+                refusjonKontaktpersonTlf = avtaleHendelseMelding.refusjonKontaktperson?.refusjonKontaktpersonTlf,
+                arbeidsgiverOnskerOgsaVarsling = avtaleHendelseMelding.refusjonKontaktperson?.ønskerVarslingOmRefusjon,
+                arbeidsgiverTlf = avtaleHendelseMelding.arbeidsgiverTlf,
+                tiltakstype = avtaleHendelseMelding.tiltakstype,
                 avtaleInnholdVersjon = avtaleHendelseMelding.versjon,
                 avtaleHendelseType = avtaleHendelseMelding.hendelseType,
                 avtaleHendelseSistEndret = avtaleHendelseMelding.sistEndret,

--- a/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
+++ b/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
@@ -1,8 +1,8 @@
--- Tømmer tabellen siden dataene ikke er i bruk ennå, og backfill kjøres på nytt med nye felter.
+-- Tømmer tabellen siden dataene ikke er i bruk ennå, og backfill kjøres på nytt med nye felter slik vi kan ha not null på tiltakstype som nå blir lagt til.
 truncate table arbeidsgiver_refusjon_kontaktperson;
 
 alter table arbeidsgiver_refusjon_kontaktperson
-    add column arbeidsgiver_tlf varchar,
-    add column tiltakstype      varchar not null default 'UKJENT'; -- default trengs visst siden det teoretisk kan ligge rader der uten tiltakstype.
+    add column arbeidsgiver_tlf varchar not null,
+    add column tiltakstype      varchar not null;
 
 alter table arbeidsgiver_refusjon_kontaktperson alter column refusjon_kontaktperson_tlf drop not null;

--- a/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
+++ b/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
@@ -1,0 +1,4 @@
+alter table arbeidsgiver_refusjon_kontaktperson
+    add column arbeidsgiver_tlf varchar,
+    add column tiltakstype      varchar,
+    alter column refusjon_kontaktperson_tlf drop not null;

--- a/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
+++ b/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
@@ -1,5 +1,8 @@
+-- Tømmer tabellen siden dataene ikke er i bruk ennå, og backfill kjøres på nytt med nye felter.
+truncate table arbeidsgiver_refusjon_kontaktperson;
+
 alter table arbeidsgiver_refusjon_kontaktperson
     add column arbeidsgiver_tlf varchar,
-    add column tiltakstype      varchar;
+    add column tiltakstype      varchar not null default 'UKJENT'; -- default trengs visst siden det teoretisk kan ligge rader der uten tiltakstype.
 
 alter table arbeidsgiver_refusjon_kontaktperson alter column refusjon_kontaktperson_tlf drop not null;

--- a/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
+++ b/src/main/resources/db/migration/V10__arbeidsgiver_refusjon_kontaktperson_nye_felter.sql
@@ -1,4 +1,5 @@
 alter table arbeidsgiver_refusjon_kontaktperson
     add column arbeidsgiver_tlf varchar,
-    add column tiltakstype      varchar,
-    alter column refusjon_kontaktperson_tlf drop not null;
+    add column tiltakstype      varchar;
+
+alter table arbeidsgiver_refusjon_kontaktperson alter column refusjon_kontaktperson_tlf drop not null;

--- a/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepositoryTest.kt
@@ -108,7 +108,7 @@ class ArbeidsgiverRefusjonKontaktpersonRepositoryTest {
         avtaleId: UUID = UUID.randomUUID(),
         tlf: String? = "99887766",
         onskerVarsling: Boolean? = true,
-        arbeidsgiverTlf: String? = "44556677",
+        arbeidsgiverTlf: String = "44556677",
         tiltakstype: Tiltakstype = Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
         versjon: Int = 1,
     ) = RefusjonKontaktpersonEntitet(

--- a/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/tiltak/tiltaknotifikasjon/arbeidsgivernotifikasjon/ArbeidsgiverRefusjonKontaktpersonRepositoryTest.kt
@@ -2,6 +2,7 @@ package no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon
 
 import com.ninjasquad.springmockk.MockkBean
 import no.nav.tiltak.tiltaknotifikasjon.avtale.HendelseType
+import no.nav.tiltak.tiltaknotifikasjon.avtale.Tiltakstype
 import no.nav.tiltak.tiltaknotifikasjon.brukernotifikasjoner.tables.ArbeidsgiverRefusjonKontaktperson.Companion.ARBEIDSGIVER_REFUSJON_KONTAKTPERSON
 import no.nav.tiltak.tiltaknotifikasjon.kafka.MinSideProdusent
 import no.nav.tiltak.tiltaknotifikasjon.kafka.TiltakNotifikasjonKvitteringProdusent
@@ -105,13 +106,17 @@ class ArbeidsgiverRefusjonKontaktpersonRepositoryTest {
 
     private fun lagEntitet(
         avtaleId: UUID = UUID.randomUUID(),
-        tlf: String = "99887766",
+        tlf: String? = "99887766",
         onskerVarsling: Boolean? = true,
+        arbeidsgiverTlf: String? = "44556677",
+        tiltakstype: Tiltakstype = Tiltakstype.MIDLERTIDIG_LONNSTILSKUDD,
         versjon: Int = 1,
     ) = RefusjonKontaktpersonEntitet(
         avtaleId = avtaleId,
         refusjonKontaktpersonTlf = tlf,
         arbeidsgiverOnskerOgsaVarsling = onskerVarsling,
+        arbeidsgiverTlf = arbeidsgiverTlf,
+        tiltakstype = tiltakstype,
         avtaleInnholdVersjon = versjon,
         avtaleHendelseType = HendelseType.ENDRET,
         avtaleHendelseSistEndret = Instant.now(),


### PR DESCRIPTION
Tabellen `arbeidsgiver_refusjon_kontaktperson` utvides for å ha nok informasjon til å avgjøre hvem som skal motta SMS-varsel ved `REFUSJON_KLAR`.
Vi trenger arbeidsgivers telefonnummer også, i de tilfellene bare arbeidsgiver eller begge skal motta varsling, og vi trenger tiltakstype for å lage merkelapp på sakene i min-side-arbeidsgiver.

Endret consumerGrouId for å rekjøre hele topicen og populere med disse 2 nye feltene. Fjernet sjekk på at kun meldinger som har refusjonKontaktperson blir lagret.

Tømmer tabellen før utvidelse slik at vi kan sette de nye feltene som not null, vi leser også kun hendelser fra inngåtte avtaler, da kan vi også gå ut ifra at arbeidsgiverTlf ikke er null.