### PR TITLE
ny backfill - leste ikke inngått hendelser

### DIFF
--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
@@ -67,6 +67,6 @@ fun HendelseType.skalSendeSmsTilArbeidsgiver(): Boolean =
 
 fun HendelseType.kanOppdatereRefusjonKontaktperson(): Boolean =
     when (this) {
-        HendelseType.AVTALE_INNGÅTT, HendelseType.KONTAKTINFORMASJON_ENDRET -> true
+        HendelseType.ENDRET, HendelseType.AVTALE_INNGÅTT, HendelseType.KONTAKTINFORMASJON_ENDRET -> true
         else -> false
     }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/avtale/HendelseType.kt
@@ -67,6 +67,6 @@ fun HendelseType.skalSendeSmsTilArbeidsgiver(): Boolean =
 
 fun HendelseType.kanOppdatereRefusjonKontaktperson(): Boolean =
     when (this) {
-        HendelseType.ENDRET, HendelseType.KONTAKTINFORMASJON_ENDRET -> true
+        HendelseType.AVTALE_INNGÅTT, HendelseType.KONTAKTINFORMASJON_ENDRET -> true
         else -> false
     }

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
@@ -62,8 +62,8 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
 
     private fun skalBehandles(avtaleHendelseMelding: AvtaleHendelseMelding): Boolean {
         if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return false // arbeidstrening har ikke økonomi
-        if (avtaleHendelseMelding.arbeidsgiverTlf == null) return false // skal ikke kunne skje på inngått avtale
         if (avtaleHendelseMelding.avtaleInngått == null) return false // refusjonsvarslinger har ingen nytte på ting som ikke er inngått
+        if (avtaleHendelseMelding.arbeidsgiverTlf == null) return false // skal ikke kunne skje på inngått avtale
         if (!avtaleHendelseMelding.hendelseType.kanOppdatereRefusjonKontaktperson()) return false
         // Kjører backfill frem til toggle skrus på, da tar AvtaleHendelseConsumer over
         return !unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")

--- a/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
+++ b/src/main/kotlin/no/nav/tiltak/tiltaknotifikasjon/kafka/RefusjonKontaktpersonConsumer.kt
@@ -6,6 +6,7 @@ import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.ArbeidsgiverRef
 import no.nav.tiltak.tiltaknotifikasjon.arbeidsgivernotifikasjon.RefusjonKontaktpersonEntitet
 import no.nav.tiltak.tiltaknotifikasjon.avtale.AvtaleHendelseMelding
 import no.nav.tiltak.tiltaknotifikasjon.avtale.Tiltakstype
+import no.nav.tiltak.tiltaknotifikasjon.avtale.kanOppdatereRefusjonKontaktperson
 import no.nav.tiltak.tiltaknotifikasjon.utils.jacksonMapper
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.slf4j.LoggerFactory
@@ -23,7 +24,7 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
     private val antallLagret = AtomicLong(0)
 
     @KafkaListener(topics = [Topics.AVTALE_HENDELSE_COMPACT],
-        groupId = "tiltak-notifikasjon-refusjon-kontaktperson-5",
+        groupId = "tiltak-notifikasjon-refusjon-kontaktperson-6",
         properties = ["auto.offset.reset=earliest"], // Hmm, trodde ikke dette var nødvendig.. tydeligvis.
     )
     fun konsumer(melding: ConsumerRecord<String, String>) {
@@ -47,7 +48,6 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
                 deltakerFornavn = avtaleHendelseMelding.deltakerFornavn,
             )
             refusjonKontaktpersonRepository.save(refusjonKontaktperson)
-            log.info("Lagret refusjon kontaktperson via backfill, offset: ${melding.offset()}")
             val count = antallLagret.incrementAndGet()
             if (count % 100 == 0L) {
                 log.info("Backfill refusjon kontaktperson: $count meldinger lagret, siste offset ${melding.offset()}")
@@ -62,8 +62,9 @@ class RefusjonKontaktpersonConsumer(val refusjonKontaktpersonRepository: Arbeids
 
     private fun skalBehandles(avtaleHendelseMelding: AvtaleHendelseMelding): Boolean {
         if (avtaleHendelseMelding.tiltakstype == Tiltakstype.ARBEIDSTRENING) return false // arbeidstrening har ikke økonomi
-        if (avtaleHendelseMelding.avtaleInngått == null) return false // refusjonsvarslinger har ingen nytte på ting som ikke er inngått
         if (avtaleHendelseMelding.arbeidsgiverTlf == null) return false // skal ikke kunne skje på inngått avtale
+        if (avtaleHendelseMelding.avtaleInngått == null) return false // refusjonsvarslinger har ingen nytte på ting som ikke er inngått
+        if (!avtaleHendelseMelding.hendelseType.kanOppdatereRefusjonKontaktperson()) return false
         // Kjører backfill frem til toggle skrus på, da tar AvtaleHendelseConsumer over
         return !unleash.isEnabled("refusjon-kontaktperson-backfill-ferdig")
     }


### PR DESCRIPTION
Det ble gjort en liten bommert her, toggelen ble flippet til å lese fra avtalehendelseconsumeren, men her lå det en sjekk som kun leste inngåtte avtaler med hendelsetypene endret og kontaktinfo endret, men endret skjer jo ikke etter at avtalen er inngått, og da får vi kun kontaktinfo endret, ergo mister vi endel, vi burde hatt med inngått hendelsen også. 

Har lagt til den her, samtidig som groupid er resatt, så vil vi spole gjennom hele topicen fra start, og lese alt som er blitt inngått eller endret kontaktinfo på, og lagre det, og i jooq er det on conflict do update på avtaleid, så det funker fint, vi vil oppdatere om vi får samme avtaleId, men ellers opprette. Så det er idempotens der.

Før denne merges må vi flippe toggelen igjen...